### PR TITLE
http://tokbox.bintray.com/maven has discontinued

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -12,17 +12,15 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url  "https://tokbox.bintray.com/maven/"
-        }
+        mavenCentral()
     }
 }
 
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.opentok.android:opentok-android-sdk:2.16.+'
-    compile 'com.android.support:appcompat-v7:23.1.0'
-    compile 'com.android.support:design:28.0.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.opentok.android:opentok-android-sdk:2.20.1'
+    implementation 'com.android.support:appcompat-v7:23.1.0'
+    implementation 'com.android.support:design:28.0.0'
 }


### PR DESCRIPTION
Getting build errors because Bintray has been discontinued.

When running a clean-build, I am now getting the below error:

> What went wrong:
Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
> Could not resolve com.opentok.android:opentok-android-sdk:2.16.+.
  Required by:
      project :app
   > Failed to list versions for com.opentok.android:opentok-android-sdk.
      > Unable to load Maven meta-data from https://tokbox.bintray.com/maven/com/opentok/android/opentok-android-sdk/maven-metadata.xml.
         > Could not HEAD 'https://tokbox.bintray.com/maven/com/opentok/android/opentok-android-sdk/maven-metadata.xml'. Received status code 502 from server: Bad Gateway


In researching the issue, I found that bintray may have finally been discontinued - https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/ which would explain the 502 error code above.

Doing some digging I found this potential fix on github - https://github.com/opentok/cordova-plugin-opentok/issues/205#issuecomment-887619276 and successfully tested the changes locally.
