### PR TITLE
Use OTXCFramework Cocoapod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bidwrangler-opentok-plugin",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-coffee": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bidwrangler-opentok-plugin",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-coffee": "^0.10.1",

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,7 +74,7 @@
       <framework src="CFNetwork.framework" />
       <podspec>
          <pods use-frameworks="true">
-             <pod name="OpenTok" spec="~> 2.24.2" />
+             <pod name="OTXCFramework" spec="~> 2.24.2" />
          </pods>
       </podspec>
 


### PR DESCRIPTION
Reading this: https://tokbox.com/developer/sdks/ios/

Noticed this comment:
> Version 2.25.1 of the SDK removes support for FAT binaries (previously available as Pod "OpenTok"). Only XCFramework artifacts are supported (available as Pod "OTXCFramework").

It's not totally clear what FAT binaries are but snooping with Dad we hacked the cordova-ios package to *force* the entire build to use `EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64` and it worked but felt wrong.  So we were thinking that maybe the entire problem was that OpenTok 2.24.2 was forcing *everyone* else to exclude arm64 from the simulator which felt bad.

Reading lots of ambiguous articles on the internet about whether the simulator supported ARM64 was unclear but when we successfully launched a *fully* ARM64 app just be omitting OpenTok it seemed like OpenTok was the problem.  So we hunted around and found https://github.com/CocoaPods/cocoapods.org/issues/454 which pretty clearly implied there was *another* Cocoapod for OpenTok of a different sort.

So we tried this change and everything builds and launches correctly when you modify bw_phonegap like so
```diff
diff --git a/package.json b/package.json
index 5c79fb65..62597104 100644
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@havesource/cordova-plugin-push": "^4.0.0-dev.0",
-    "bidwrangler-opentok-plugin": "1.0.16",
+    "bidwrangler-opentok-plugin": "github:bidwrangler/bidwrangler-opentok-plugin#otxcframework",
     "cordova-android": "11.0.0",
     "cordova-ios": "^6.3.0",
     "cordova-plugin-androidx-adapter": "1.1.3",
```

Tomorrow I want to do a build of *some* app and fully test using Tokbox streaming.  I will need some help learning how to do that.  Dad suggested that maybe we do a new release of BWStaging app with this latest code and Testflight...

Going forward he also said that we can stop doing releases to npmjs.org and can instead just reference the github repo like above (NOTE: when we merge this we can drop `#otxcframework` since we will just reference the master branch).  Dad says, the reason we needed to do npmjs.org releases previously was because Phonegap Build didn't have access to repos besides `bw_phonegap` so it could *only* fetch packages from npmjs.org.  Since we're no longer using that service and are building locally with fastlane/Xcode as a developer that has github access we don't need fully released packages anymore.

So... I think the todo list is something like this:

- [ ] review and merge this PR
- [ ] update the new_master branch in bidwrangler/bw_phonegap to reference bidwrangler/bidwrangler-opentok-plugin (instead of the version in npmjs.org)
- [ ] down merge that change into an app that we want to build (e.g. Ray Farm or for testing BWStaging)
- [ ] Double check that fastlane is taking the screenshots that we want it to take
- [ ] Do a build targetting TestFlight that we can install on our phones
- [ ] Setup a LIVE auction
- [ ] Practice streaming AND viewing *from* the phone
- [ ] Double check push notifications too
- [ ] Rinse and repeat a bunch of times for all the other apps in the queue (but happily this should all work fine with fastlane including screenshots)